### PR TITLE
Add moment & lodash to restricted imports and providing info for alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,12 @@ To use this preset/ruleset add the following to your configuration file:
     "extends": "@uumacher/eslint-config"
 }
 ```
+
+## Additional info
+Currently the configuration will print a warning if you use the following packages, because of the enormous extra bundle-size that they will probably cause:
+
+### moment.js
+Please use [date-fns](https://date-fns.org/) or [Luxon](https://moment.github.io/luxon/) instead!
+
+### lodash
+Please check if equivalent native methods exist (e.g. Array.* or Object.*) or use [lodash-es](https://www.npmjs.com/package/lodash-es) instead!

--- a/index.js
+++ b/index.js
@@ -16,15 +16,21 @@ module.exports = {
     },
     plugins: ['prettier'],
     rules: {
-        'prettier/prettier': [
-            'error',
-            {
+        'prettier/prettier': ['error', {
                 printWidth: 140,
                 semi: true,
                 singleQuote: true,
                 tabWidth: 4,
                 trailingComma: 'none'
-            }
-        ]
+        }],
+        'no-restricted-imports': ['warn', {
+            'paths': [{
+                'name': 'moment',
+                'message': 'Please use date-fns or Luxon instead!'
+            }, {
+                'name': 'lodash',
+                'message': 'Please check if equivalent native methods exist (e.g. Array.* or Object.*) or use lodash-es instead!'
+            }]
+        }]
     }
 };

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "uum"
   ],
   "dependencies": {
-    "eslint-config-prettier": "^6.7.0",
-    "eslint-plugin-prettier": "^3.1.1",
+    "eslint-config-prettier": "^6.10.0",
+    "eslint-plugin-prettier": "^3.1.2",
     "prettier": "^1.19.1"
   }
 }


### PR DESCRIPTION
Da mir ein bekannter Artikel nochmal untergekommen ist (https://addyosmani.com/blog/disallow-imports/) dachte ich es wäre doch passend unsere ESLint-Konfiguration zu erweitern und generell schonmal die Grundlage zu schaffen um so in Zukunft gewisse Abhängigkeiten auszuschließen, bzw. Entwickler zu warnen und Alternativen aufzuzeigen.

Für mehr Infos: https://eslint.org/docs/rules/no-restricted-imports

Jetzt wird bei der Verwendung von **moment** und **lodash** via NPM eine Warnung ausgegeben. Beide Pakete sind dafür bekannt bei unbedachter Verwendung enorme Bundle-sizes zu generieren 😱

Direkt eine *error*-Regel daraus zu erstellen erscheint mir als etwas zu restriktiv, da u.U. in bestehenden Projekten bereits Abhängigkeiten existieren könnten.

Generell ist das ganze auch für Node-Module möglich, was wir uns vielleicht auch mal vornehmen könnten in einem anderen PR ;)